### PR TITLE
Update aboutus.md

### DIFF
--- a/Docs/joomla/templates/plethora/aboutus.md
+++ b/Docs/joomla/templates/plethora/aboutus.md
@@ -135,6 +135,7 @@ Below is a brief rundown of the modules used to make up the demo page.
 
 ~~~ .html
 <div class="gantry-row">
+<div class="gantry-width-container">
     <div class="gantry-width-50">
         <div class="gantry-width-spacer">
             <span class="rt-image"><img src="images/rocketlauncher/pages/about-us/img-01.jpg" alt="image" /></span>
@@ -150,6 +151,7 @@ Below is a brief rundown of the modules used to make up the demo page.
             </div>
         </div>
     </div>
+</div>
 </div>
 <div class="clear"></div>
 ~~~
@@ -185,6 +187,7 @@ Below is a brief rundown of the modules used to make up the demo page.
 
 ~~~ .html
 <div class="gantry-row">
+<div class="gantry-width-container">
     <div class="gantry-width-33">
         <div class="gantry-width-spacer">
             <span class="rt-image"><img src="images/rocketlauncher/pages/about-us/img-02.jpg" alt="image" /></span>
@@ -206,6 +209,7 @@ Below is a brief rundown of the modules used to make up the demo page.
             <p>Engage worldwide methodologies with web-enabled technology. Interactively coordinate proactive e-commerce via process-centric outside the box thinking.</p>
         </div>
     </div>
+</div>
 </div>
 <div class="clear"></div>
 ~~~


### PR DESCRIPTION
Line 138 <div class="gantry-width-container">
Line 154 </div>

Line 190 <div class="gantry-width-container">
Line 213 </div>

The code and line numbers associated with where they need to be placed in this document are shown above. Without those lines of code added the contents between the <div> tags would stack on top of each other not sit sided by side like the demo shows
. 
This was observed with a fresh install of Joomla!™ 3.3.6, Gantry™ and this Plethora documentation. The difference between the working demo and the version and code copied from this documentation were compared and implemented and the correction was valid in both places. I suggest placing this line in the documentation to prevent others from having this issue.

CT
